### PR TITLE
adds show emotes for mobile

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -356,6 +356,11 @@
         </div>
       </div>
 
+
+      <button id="btn-emotes" class="emotes-container">
+        <img src="./img/misc/emotes_icon.svg"/>
+      </button>
+
       <div id="team-container"></div>
 
       <div class="ui-leaderboard">

--- a/client/index.html
+++ b/client/index.html
@@ -333,6 +333,8 @@
               <span class="counter-text" id="ui-kills">0</span>
             </div>
 
+            <button id="btn-game-menu" class="gas-card fa-solid fa-bars"></button>
+
             <div id="debug-hud">
               <div id="fps-counter"></div>
               <div id="ping-counter"></div>

--- a/client/src/scripts/managers/uiManager.ts
+++ b/client/src/scripts/managers/uiManager.ts
@@ -193,7 +193,6 @@ export class UIManager {
         createTeamMenu: $<HTMLDivElement>("#create-team-menu"),
 
         emoteButton: $<HTMLButtonElement>("#btn-emotes"),
-        pingToggle: $<HTMLButtonElement>("#btn-toggle-ping"),
         menuButton: $<HTMLButtonElement>("#btn-game-menu"),
 
         emoteWheel: $<HTMLDivElement>("#emote-wheel"),
@@ -679,7 +678,6 @@ export class UIManager {
 
             if (this.game.inputManager.isMobile) {
                 this.ui.emoteButton.toggle(!spectating);
-                this.ui.pingToggle.toggle(!spectating);
                 this.ui.menuButton.toggle(!spectating);
             }
         }

--- a/client/src/scripts/objects/player.ts
+++ b/client/src/scripts/objects/player.ts
@@ -1303,9 +1303,6 @@ export class Player extends GameObject.derive(ObjectCategory.Player) {
     showEmote(type: AllowedEmoteSources): void {
         if (this.game.inputManager.isMobile) {
             this.game.inputManager.emoteWheelActive = false;
-            this.game.uiManager.ui.emoteButton
-                .removeClass("btn-alert")
-                .addClass("btn-primary");
         }
 
         this.anims.emote?.kill();

--- a/client/src/scripts/ui/game.ts
+++ b/client/src/scripts/ui/game.ts
@@ -609,7 +609,7 @@ function setupMobileControls(game: Game): void {
         ui.activeAmmo.on("click", () => GAME_CONSOLE.handleQuery("reload", "never"));
         ui.emoteWheel.css("top", "50%").css("left", "50%");
         ui.menuButton.on("click", () => ui.gameMenu.toggle());
-        ui.emoteButton.on("click", () => ui.emoteWheel.show());
+        ui.emoteButton.on("click", () => ui.emoteWheel.toggle());
 
     }
 

--- a/client/src/scripts/ui/game.ts
+++ b/client/src/scripts/ui/game.ts
@@ -611,14 +611,6 @@ function setupMobileControls(game: Game): void {
         ui.menuButton.on("click", () => ui.gameMenu.toggle());
         ui.emoteButton.on("click", () => ui.emoteWheel.show());
 
-        ui.pingToggle.on("click", () => {
-            inputManager.pingWheelActive = !inputManager.pingWheelActive;
-            const { pingWheelActive } = inputManager;
-            ui.pingToggle
-                .toggleClass("btn-danger", pingWheelActive)
-                .toggleClass("btn-primary", !pingWheelActive);
-            game.uiManager.updateEmoteWheel();
-        });
     }
 
     $("#tab-mobile").toggle(isMobile.any);
@@ -630,44 +622,17 @@ function setupEmoteWheel(game: Game): void {
     const createEmoteWheelListener = (slot: typeof EMOTE_SLOTS[number], emoteSlot: number): void => {
         $(`#emote-wheel .emote-${slot}`).on("click", () => {
             ui.emoteWheel.hide();
-            let clicked = true;
 
             if (inputManager.pingWheelActive) {
                 const ping = game.uiManager.mapPings[emoteSlot];
-
-                setTimeout(() => {
-                    let gameMousePosition: Vector;
-
-                    if (game.map.expanded) {
-                        ui.game.one("click", () => {
-                            gameMousePosition = inputManager.pingWheelPosition;
-
-                            if (ping && inputManager.pingWheelActive && clicked) {
-                                inputManager.addAction({
-                                    type: InputActions.MapPing,
-                                    ping,
-                                    position: gameMousePosition
-                                });
-                                clicked = false;
-                            }
-                        });
-                    } else {
-                        ui.game.one("click", e => {
-                            const globalPos = Vec.create(e.clientX, e.clientY);
-                            const pixiPos = game.camera.container.toLocal(globalPos);
-                            gameMousePosition = Vec.scale(pixiPos, 1 / PIXI_SCALE);
-
-                            if (ping && inputManager.pingWheelActive && clicked) {
-                                inputManager.addAction({
-                                    type: InputActions.MapPing,
-                                    ping,
-                                    position: gameMousePosition
-                                });
-                                clicked = false;
-                            }
-                        });
-                    }
-                }, 100);
+                
+                if (game.map.expanded && ping && inputManager.pingWheelActive) {
+                    inputManager.addAction({
+                        type: InputActions.MapPing,
+                        ping,
+                        position: inputManager.pingWheelPosition
+                    });
+                }
             } else {
                 const emote = game.uiManager.emotes[emoteSlot];
                 if (emote) {

--- a/client/src/scripts/ui/game.ts
+++ b/client/src/scripts/ui/game.ts
@@ -608,7 +608,7 @@ function setupMobileControls(game: Game): void {
         ui.interactKey.html('<img src="./img/misc/tap-icon.svg" alt="Tap">');
         ui.activeAmmo.on("click", () => GAME_CONSOLE.handleQuery("reload", "never"));
         ui.emoteWheel.css("top", "50%").css("left", "50%");
-        ui.menuButton.on("click", () => ui.gameMenu.toggle());
+        ui.menuButton.on("click", () => ui.gameMenu.fadeToggle(250));
         ui.emoteButton.on("click", () => ui.emoteWheel.toggle());
 
     }

--- a/client/src/scss/pages/client/game.scss
+++ b/client/src/scss/pages/client/game.scss
@@ -53,6 +53,7 @@
 }
 
 #minimap-border {
+  position: relative;
   display: inline-block;
   width: 220px;
   height: 220px;
@@ -1525,32 +1526,46 @@
   z-index: 1;
   //noinspection CssUnknownTarget
   background-image: url("/img/misc/emote_wheel.svg");
+  background-size: 100%;
+  background-repeat: no-repeat;
 
   & > div {
     width: 84px;
     height: 84px;
-    background-size: 84px 84px;
+    background-size: 100%;
+    background-repeat: no-repeat;
     position: absolute;
   }
 
   .emote-top {
-    top: 14px;
-    left: 101px;
+    left: 50%;
+    transform: translateX(-50%);
+
+    margin-top: 14px;
   }
 
   .emote-right {
-    right: 14px;
-    top: 101px;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+
+    margin-right: 14px;
   }
 
   .emote-bottom {
-    bottom: 14px;
-    left: 101px;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+
+    margin-bottom: 14px;
   }
 
   .emote-left {
-    left: 14px;
-    top: 101px;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+
+    margin-left: 14px;
   }
 
   .button-center {
@@ -1559,6 +1574,16 @@
     left: calc(143px - calc(42px / 2));
     top: calc(101px + calc(42px / 2));
   }
+
+    @media screen and (max-width: variables.$screen_medium) {
+      width: 228px;
+      height: 228px;
+
+      > div {
+        width: 58px;
+        height: 58px;
+      }
+    }
 }
 
 #emote-wheel-highlight,

--- a/client/src/scss/pages/client/game.scss
+++ b/client/src/scss/pages/client/game.scss
@@ -1737,6 +1737,7 @@
   }
 }
 
+.emotes-container,
 .inventory-items,
 #scopes-container-mobile,
 #weapons-container,
@@ -1824,5 +1825,31 @@
   100% {
     box-shadow: none;
     background-color: none;
+  }
+}
+
+.emotes-container {
+  position: fixed;
+  bottom: 5px;
+  right: 5px;
+  gap: 6px;
+  
+  display: none;
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 6px;
+  background-color: palette.$transparent_bg;
+
+  width: 32px;
+  height: 32px;
+
+  img {
+    width: 16px;
+    height: 16px;
+  }
+  
+  @media screen and (max-width: variables.$screen_medium) {
+    display: flex;
   }
 }

--- a/client/src/scss/pages/client/game.scss
+++ b/client/src/scss/pages/client/game.scss
@@ -1762,6 +1762,7 @@
   }
 }
 
+#btn-game-menu,
 .emotes-container,
 .inventory-items,
 #scopes-container-mobile,
@@ -1876,5 +1877,14 @@
   
   @media screen and (max-width: variables.$screen_medium) {
     display: flex;
+  }
+}
+
+#btn-game-menu {
+  position: relative;
+  display: none;
+
+  @media screen and (max-width: variables.$screen_medium) {
+    display: block;
   }
 }


### PR DESCRIPTION
## Summary 
in this PR Implementing related emotes/pings for cross-platform

1. display emotes for mobile
2. display setting menu for mobile
3. in the desktop when using ping you don't need hold `C` keyboard
4. allow mobile using ping in minimap
> however joystick cannot work together when you open minimap, because impact touching

## Demo 

Ping:
<img width="785" height="497" alt="Screenshot 2025-09-07 at 19 36 56" src="https://github.com/user-attachments/assets/14588c08-5000-458a-acd7-6faf243145c2" />

Emotes
<img width="800" height="496" alt="Screenshot 2025-09-07 at 19 41 22" src="https://github.com/user-attachments/assets/35cc2609-d46f-4d49-8463-6b7145a27a70" />

Menu:
<img width="792" height="499" alt="Screenshot 2025-09-07 at 20 01 08" src="https://github.com/user-attachments/assets/ffa3a1ac-565f-40e7-8ab8-1eaef47514e5" />
