### PR TITLE
inventory should not overlay joystick

### DIFF
--- a/client/src/scss/pages/client/inventory.scss
+++ b/client/src/scss/pages/client/inventory.scss
@@ -8,6 +8,8 @@
     inset: 0 0 auto auto;
     padding: 6px;
 
+    // this make joystick can work, because width items don't hide it
+    width: 0px; 
     height: 100%;
 
     display: flex;


### PR DESCRIPTION
this PR fix inventory width overlay, just make **individual** items have `width-self`

<img width="758" height="407" alt="Screenshot 2025-09-10 at 21 13 50" src="https://github.com/user-attachments/assets/f5894993-d232-48f0-832a-0025d31d56fe" />
